### PR TITLE
Validez de período de certificado

### DIFF
--- a/web/assets/js/invoice.js
+++ b/web/assets/js/invoice.js
@@ -154,8 +154,13 @@ class Receipt {
 							{ id: "terexoris", uri: "", hash: hashAlgorithm, transforms: transforms }
 						],
 						x509: [x509],
-						//~ signerRole: { claimed: ["BOSS"] },
-						signingCertificate: x509
+						signerRole: { claimed: ["Taxpayer"] },
+						/*
+						 * It exists, but Sunat does not handle big numbers (20 bytes) in serial numbers so was removed.
+						 * Structure can be found in http://www.datypic.com/sc/ubl21/e-xades_SigningCertificate.html
+						 * It could be enabled using global options.
+						 */
+						// signingCertificate: x509
 					}
 				)
 			})

--- a/web/assets/js/person.js
+++ b/web/assets/js/person.js
@@ -123,27 +123,27 @@ var Taxpayer = function() {
 			//prepend two digits of year
 			validityNotAfter = ( parseInt(validityNotAfter.substring(0, 2)) < 50 ? "20" : "19" ) + validityNotAfter
 		}
-		timeNotAfter = new Date(Date.UTC(
+		timeNotAfter = Date.UTC(
 			validityNotAfter.substring(0, 4),
-			validityNotAfter.substring(4, 6),
+			parseInt(validityNotAfter.substring(4, 6)) - 1,
 			validityNotAfter.substring(6, 8),
 			validityNotAfter.substring(8, 10),
 			validityNotAfter.substring(10, 12),
 			validityNotAfter.substring(12, 14)
-		))
+		)
 		if(notBefore.type == 23) {
 			validityNotBefore = ( parseInt(validityNotBefore.substring(0, 2)) < 50 ? "20" : "19" ) + validityNotBefore
 		}
-		timeNotBefore = new Date(Date.UTC(
+		timeNotBefore = Date.UTC(
 			validityNotBefore.substring(0, 4),
-			validityNotBefore.substring(4, 6),
+			parseInt(validityNotBefore.substring(4, 6)) - 1,
 			validityNotBefore.substring(6, 8),
 			validityNotBefore.substring(8, 10),
 			validityNotBefore.substring(10, 12),
 			validityNotBefore.substring(12, 14)
-		))
+		)
 
-		const now = new Date()
+		const now = Date.now()
 		if(now < timeNotBefore || now > timeNotAfter) {
 			return -1
 		}


### PR DESCRIPTION
- Se corrige la obtención de días para saber la cantidad de días que le queda al certificado digital tributario.
- Se borra un campo personalizado en la sección de firma porque hay certificados con números de serie extremadamente largos y Sunat no los toma como enteros válidos porque está fuera de su rango.